### PR TITLE
Added proxy functionality

### DIFF
--- a/LoginAudit.ps1
+++ b/LoginAudit.ps1
@@ -6,6 +6,9 @@ $tokenID = "123456789:ABC-DEFghIJkLMNOPqrstUvWxYZ"
 $chatsID = "-098765432", "-123456789"
 # Note: group ID's typically start with a minus sign
 
+$proxyUrl = ""
+# If you're need a proxy for connecting to Telegram, write down proxy url (http://example.com:8123 for example)
+# otherwise just leave variable empty
 
 # Logon Types
 $LogonType = $(1 .. 12)
@@ -123,5 +126,12 @@ $ip = $ip.IPAddressToString
 
 #output the results to Telegram using an HTTP GET request
 foreach( $chatID in $chatsID) {
-	curl "https://api.telegram.org/bot$tokenID/sendMessage?chat_id=$chatID&parse_mode=Markdown&text=*System Login Activity* %0A*$env:COMPUTERNAME* : $ip $result"
+	$message = "https://api.telegram.org/bot$tokenID/sendMessage?chat_id=$chatID&parse_mode=Markdown&text=*System Login Activity* %0A*$env:COMPUTERNAME* : $ip $result"
+
+	if ($proxyUrl.Length -gt 0) {
+		curl -Proxy $proxyUrl $message
+	}
+	else {
+		curl $message
+	}
 }


### PR DESCRIPTION
Hi there! 
Due some circumstances in my country i've added proxy functionality for sending messages to Telegram

For using proxy just need add a invoke-webrequest compatible proxy string in $proxyUrl 
As for proxy protocols, the most popular ones are HTTP, HTTPS, and SOCKS. 
Invoke-WebRequest in PowerShell 5.1 only supports HTTP while in PowerShell 7.x it also supports HTTPS and SOCKS.

New function were successfully tested at Windows 10 22H2 (19045.6456) and Windows Server 2019 1809 (17763.5576) using http proxy
